### PR TITLE
Fix the default value type of 'compile_commands_rolling_size'

### DIFF
--- a/plugin/zxz-moe-bis/package.json
+++ b/plugin/zxz-moe-bis/package.json
@@ -104,7 +104,7 @@
             "type": "integer",
             "markdownDescription": "Rolling size of compile_commands.json",
             "order": 9,
-            "default": "300000000"
+            "default": 300000000
           },
           "bis.default_workspace": {
             "type": "string",


### PR DESCRIPTION
needed type integer, not string