### PR TITLE
Enhance build targets tree view

### DIFF
--- a/bisproject_aspect.bzl
+++ b/bisproject_aspect.bzl
@@ -31,6 +31,9 @@ def _bis_aspect_impl(target, ctx):
     if ctx.rule.kind.endswith("_import"):
         # skip some imported targets (e.g. objc_import, apple_static_framework_import, apple_dynamic_framework_import, etc.)
         return []
+    if ctx.rule.kind == 'filegroup':
+        # skip filegroup targets
+        return []
     direct_index_dependents = []
     direct_outputs = [("bis artifacts {}".format(target.label), target.files)]
     direct_xctest_infos = []

--- a/bisproject_aspect.bzl
+++ b/bisproject_aspect.bzl
@@ -28,6 +28,9 @@ def _transitive_infos(*, ctx):
 
 
 def _bis_aspect_impl(target, ctx):
+    if ctx.rule.kind.endswith("_import"):
+        # skip some imported targets (e.g. objc_import, apple_static_framework_import, apple_dynamic_framework_import, etc.)
+        return []
     direct_index_dependents = []
     direct_outputs = [("bis artifacts {}".format(target.label), target.files)]
     direct_xctest_infos = []

--- a/plugin/zxz-moe-bis/package.json
+++ b/plugin/zxz-moe-bis/package.json
@@ -28,6 +28,11 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "zxz-moe-bis.revealTargetInBUILD",
+        "title": "Reveal Target",
+        "enablement": "view == buildWorkspace && viewItem == artifacts"
+      },
+      {
         "command": "zxz-moe-bis.generateLaunchJson",
         "title": "bis: generate bis launch json"
       },
@@ -228,6 +233,13 @@
         {
           "command": "zxz-moe-bis.refreshTreeViewer",
           "when": "view == buildWorkspace",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "zxz-moe-bis.revealTargetInBUILD",
+          "when": "view == buildWorkspace && viewItem == artifacts",
           "group": "navigation"
         }
       ]

--- a/plugin/zxz-moe-bis/src/buildTaskProvider.ts
+++ b/plugin/zxz-moe-bis/src/buildTaskProvider.ts
@@ -22,8 +22,8 @@ export class BuildTaskProvider implements vscode.TaskProvider {
         }
 
         const compilationMode = (await picker.compilationMode()) ?? "dbg";
-        const cpu = await cpuProvider.cpu();
-        const result: vscode.Task[] = [
+        const cpu = cpuProvider.cpu();
+        return [
             this.createTask(
                 "build",
                 buildTarget!,
@@ -46,7 +46,6 @@ export class BuildTaskProvider implements vscode.TaskProvider {
                 cpu
             )
         ];
-        return result;
     }
 
     public async provideAllTasks(): Promise<vscode.Task[]> {
@@ -60,7 +59,7 @@ export class BuildTaskProvider implements vscode.TaskProvider {
         }
 
         const compilationMode = (await picker.compilationMode()) ?? "dbg";
-        const cpu = await cpuProvider.cpu();
+        const cpu = cpuProvider.cpu();
         const result: vscode.Task[] = await this.provideTasks();
 
         for (const workspaceFolder of workspaceFolders) {

--- a/plugin/zxz-moe-bis/src/treeProvider.ts
+++ b/plugin/zxz-moe-bis/src/treeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { BuildTaskProvider } from "./buildTaskProvider";
 import { targetVariable, deviceVariable, cpuVariable } from "./variables";
+import { sortBy } from "lodash";
 
 export interface ITreeItem {
     getLabel(): string;
@@ -34,7 +35,7 @@ class TreeItem implements ITreeItem {
                 this.icon = new vscode.ThemeIcon("debug-start");
             }
         } else {
-           this.icon = vscode.ThemeIcon.Folder;
+            this.icon = vscode.ThemeIcon.Folder;
         }
     }
 
@@ -91,7 +92,7 @@ class TreeItem implements ITreeItem {
         return this.icon;
     }
     getChildren(): Thenable<ITreeItem[]> {
-        return Promise.resolve(this.children);
+        return Promise.resolve(this.children).then((items) => sortBy(items, ["label", "path"]));
     }
 
     collapsibleState(): vscode.TreeItemCollapsibleState {
@@ -186,7 +187,7 @@ export class TreeProvider implements vscode.TreeDataProvider<ITreeItem> {
             new BuildTaskProvider().provideAllTasks().then((tasks) => {
                 const items = tasks.map(
                     (task) =>
-                    new TreeItem(task, task.name.replace(/^build /, ""))
+                        new TreeItem(task, task.name.replace(/^build /, ""))
                 );
                 const root = new TreeItem(undefined, "");
                 for (const item of items) {

--- a/plugin/zxz-moe-bis/src/treeProvider.ts
+++ b/plugin/zxz-moe-bis/src/treeProvider.ts
@@ -11,6 +11,7 @@ export interface ITreeItem {
     getTooltip(): string | undefined;
     getCommand(): vscode.Command | undefined;
     getContextValue(): string | undefined;
+    getPath(): string | null;
 }
 
 class TreeItem implements ITreeItem {
@@ -19,6 +20,7 @@ class TreeItem implements ITreeItem {
     label: string;
     icon: vscode.ThemeIcon;
     children: TreeItem[] = [];
+    type: string | undefined = undefined;
 
     constructor(task: vscode.Task | undefined, path: string) {
         this.task = task;
@@ -28,11 +30,14 @@ class TreeItem implements ITreeItem {
             if (path.startsWith("all index dependents ")) {
                 this.path = path.replace(/^all index dependents /, "");
                 this.icon = new vscode.ThemeIcon("wrench");
+                this.type = "dependents";
             } else if (path.startsWith("artifacts ")) {
                 this.path = path.replace(/^artifacts /, "");
                 this.icon = new vscode.ThemeIcon("debug-start");
+                this.type = "artifacts";
             } else {
                 this.icon = new vscode.ThemeIcon("debug-start");
+
             }
         } else {
             this.icon = vscode.ThemeIcon.Folder;
@@ -95,6 +100,9 @@ class TreeItem implements ITreeItem {
         return Promise.resolve(this.children).then((items) => sortBy(items, ["label", "path"]));
     }
 
+    getPath(): string | null {
+        return this.path;
+    }
     collapsibleState(): vscode.TreeItemCollapsibleState {
         if (this.children.length === 0) {
             return vscode.TreeItemCollapsibleState.None;
@@ -113,7 +121,7 @@ class TreeItem implements ITreeItem {
         };
     }
     getContextValue(): string | undefined {
-        return undefined;
+        return this.type;
     }
 }
 

--- a/plugin/zxz-moe-bis/src/utils.ts
+++ b/plugin/zxz-moe-bis/src/utils.ts
@@ -75,6 +75,31 @@ export function isBisInstalled(): Promise<void> {
     });
 }
 
+export function queryLocationOfBUILD(targetPath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        vscode.commands
+            .executeCommand<string | undefined>("zxz-moe-bis.workspace", true)
+            .then((workspaceRoot) => {
+                promisify(executeBazelCommands)(
+                    ["query", targetPath, "--output=location"],
+                    workspaceRoot
+                )
+                    .then((stdout) => {
+                        const r = RegExp(/(.*\/BUILD(?:\.bazel)?\:\d+\:\d+)\:\s+.*rule.*/)
+                        if (r.test(stdout)) {
+                            resolve(stdout.match(r)![1]);
+                        } else {
+                            logger.error("Unexpect output: ", stdout);
+                            reject(new Error("no BUILD file found"));
+                        }
+                    })
+                    .catch((error) => {
+                        reject(error);
+                    });
+            });
+    });
+}
+
 export function touchBisBuild() {
     // Touch .bis/BUILD
     const task = new vscode.Task(


### PR DESCRIPTION
- Do not aspect some imported targets in bis (bisproject_aspect.bzl).
- Sort targets by `path`
- Add `Reveal Target`  context menu on selected target
